### PR TITLE
Corrections regarding Bruker systems

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -728,8 +728,8 @@ Zeiss Xradia
 Zeiss Xradia instrument use a proprietary xrm/txrm data and meta data format. A python reader is avaialble at `DXChange <https://dxchange.readthedocs.io/en/latest/source/api/dxchange.reader.html#dxchange.reader.read_txrm>`_ .
 
 
-Bruker SkyScan 1272
-===================
+Bruker SkyScan
+==============
 
-The Bruker SkyScan 1272 instruments generates .log files for data collection and data analysis. An example is available at :ref:`Bruker`.
+Bruker SkyScan instruments generate .log files for data collection and data analysis. An example is available at :ref:`Bruker`.
 

--- a/docs/source/tomometa/lab.rst
+++ b/docs/source/tomometa/lab.rst
@@ -10,8 +10,7 @@ Bruker
 
 SkyScan 1173
 ~~~~~~~~~~~~
-
-SkyScan 1173 instruments generates the following meta-data files:
+`SkyScan 1173 <https://web.archive.org/web/20180929210503/http://bruker-microct.com/products/1173.htm>`_ instruments generate the following meta-data files:
 
     #. :download:`sample_name.log <../demo/bruker/skyscan_1173/MML0514A_gg_lumbar1_al_26.8um_2k_.log>` 
 


### PR DESCRIPTION
- api mentioned 1272, but this is valid for all Bruker systems (as far as I know)
- Add Internet Archive link to 1173